### PR TITLE
update to change diagnosis id value

### DIFF
--- a/config/props-cds.yml
+++ b/config/props-cds.yml
@@ -28,7 +28,7 @@ Properties:
   id_fields:
     study: phs_accession
     participant: study_participant_id
-    diagnosis: diagnosis_id
+    diagnosis: study_diagnosis_id
     treatment: treatment_id
     specimen: specimen_id
     sample: sample_id


### PR DESCRIPTION
Change the diagnosis id value to study_diagnosis_id instead of diagnosis_id because diagnosis_id might be duplicated between different studies.