### PR TITLE
Fix inventory bugs

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 import os
 import yaml
 
-from bento.common.utils import get_logger
+from bento.common.utils import get_logger, UPSERT_MODE
 
 class PluginConfig:
     def __init__(self, config):
@@ -97,7 +97,7 @@ class BentoConfig:
                     self.max_violations = config.get('max_violations', 10)
                     self.s3_bucket = config.get('s3_bucket')
                     self.s3_folder = config.get('s3_folder')
-                    self.loading_mode = config.get('loading_mode', 'UPSERT_MODE')
+                    self.loading_mode = config.get('loading_mode', UPSERT_MODE)
                     self.dataset = config.get('dataset')
                     self.no_parents = config.get('no_parents')
                     self.split_transactions = config.get('split_transactions')

--- a/config/config.yml.j2
+++ b/config/config.yml.j2
@@ -42,7 +42,7 @@ Config:
   s3_bucket: {{data_bucket}}
   # S3 folder for dataset
   s3_folder: {{s3_folder}}
-  # Loading mode, can be UPSERT_MODE, NEW_MODE or DELETE_MODE, default is UPSERT_MODE
-  loading_mode: UPSERT_MODE
+  # Loading mode, can be "upsert", "new" or "delete", default is "upsert"
+  loading_mode: upsert
   # Location of dataset
   dataset: "{{s3_folder}}"

--- a/config/data-loader-config.example.yml
+++ b/config/data-loader-config.example.yml
@@ -51,7 +51,7 @@ Config:
   s3_bucket:
   # S3 folder for dataset, will be overridden by --s3-folder argument
   s3_folder:
-  # Loading mode, can be UPSERT_MODE, NEW_MODE or DELETE_MODE, default is UPSERT_MODE, can be overridden by -m/--mode argument
-  loading_mode: UPSERT_MODE
+  # Loading mode, can be "upsert", "new" or "delete", default is "upsert", can be overridden by -m/--mode argument
+  loading_mode: upsert
   # Location of dataset, can be overridden by --dataset argument
   dataset: tests/data/Dataset

--- a/config/popsci-config.yml
+++ b/config/popsci-config.yml
@@ -45,7 +45,7 @@ Config:
   s3_bucket:
   # S3 folder for dataset, will be overridden by --s3-folder argument
   s3_folder:
-  # Loading mode, can be UPSERT_MODE, NEW_MODE or DELETE_MODE, default is UPSERT_MODE, can be overridden by -m/--mode argument
-  loading_mode: UPSERT_MODE
+  # Loading mode, can be "upsert", "new" or "delete", default is "upsert", can be overridden by -m/--mode argument
+  loading_mode: upsert
   # Location of dataset, can be overridden by --dataset argument
   dataset: '/data'

--- a/data_loader.py
+++ b/data_loader.py
@@ -902,7 +902,7 @@ class DataLoader:
                         else:
                             self.log.debug('Multiplier: {}, no action needed!'.format(multiplier))
                         prop_statement = ', '.join(self.get_relationship_prop_statements(properties))
-                        statement = 'MATCH (m:{0} {{ {1}: ${1} }})'.format(parent_node, parent_id_field)
+                        statement = 'MATCH (m:{0} {{ {1}: $__parentID__ }})'.format(parent_node, parent_id_field)
                         statement += ' MATCH (n:{0} {{ {1}: ${1} }})'.format(node_type,
                                                                              self.schema.get_id_field(obj))
                         statement += ' MERGE (n)-[r:{}]->(m)'.format(relationship_name)
@@ -911,7 +911,7 @@ class DataLoader:
                         statement += ' ON MATCH SET r.{} = datetime()'.format(UPDATED)
                         statement += ', {}'.format(prop_statement) if prop_statement else ''
 
-                        result = tx.run(statement, {**obj, parent_id_field: parent_id, **properties})
+                        result = tx.run(statement, {**obj, "__parentID__": parent_id, **properties})
                         count = result.consume().counters.relationships_created
                         self.relationships_created += count
                         relationship_pattern = '(:{})->[:{}]->(:{})'.format(node_type, relationship_name, parent_node)

--- a/docs/data-loader.md
+++ b/docs/data-loader.md
@@ -152,7 +152,7 @@ All of command line arguments can be specified in the configuration file. If an 
     * The loading mode, valid inputs are ````upsert````, ````new````, ````delete````
     * Command : ````-m/--mode <mode>````
     * Not Required
-    * Default Value : ````UPSERT_MODE````
+    * Default Value : ````upsert````
 * **Enable No Parent IDs Mode**
     * Does not save parent node IDs in children nodes
     * Command : ````--no-parents````

--- a/examples/icdc/icdc-local.yml
+++ b/examples/icdc/icdc-local.yml
@@ -41,7 +41,7 @@ Config:
   s3_bucket:
   # S3 folder for dataset
   s3_folder:
-  # Loading mode, can be UPSERT_MODE, NEW_MODE or DELETE_MODE, default is UPSERT_MODE
-  loading_mode: UPSERT_MODE
+  # Loading mode, can be "upsert", "new" or "delete", default is "upsert"
+  loading_mode: upsert
   # Location of dataset
   dataset: examples/icdc/dataset

--- a/loader.py
+++ b/loader.py
@@ -42,8 +42,7 @@ def parse_arguments():
     parser.add_argument('-M', '--max-violations', help='Max violations to display', nargs='?', type=int)
     parser.add_argument('-b', '--bucket', help='S3 bucket name')
     parser.add_argument('-f', '--s3-folder', help='S3 folder')
-    parser.add_argument('-m', '--mode', help='Loading mode', choices=[UPSERT_MODE, NEW_MODE, DELETE_MODE],
-                        default=UPSERT_MODE)
+    parser.add_argument('-m', '--mode', help='Loading mode', choices=[UPSERT_MODE, NEW_MODE, DELETE_MODE])
     parser.add_argument('--dataset', help='Dataset directory')
     parser.add_argument('--split-transactions', help='Creates a separate transaction for each file',
                         action='store_true')
@@ -157,7 +156,7 @@ def process_arguments(args, log):
     if args.mode:
         config.loading_mode = args.mode
     if not config.loading_mode:
-        config.loading_mode = "UPSERT_MODE"
+        config.loading_mode = UPSERT_MODE
 
     if args.max_violations:
         config.max_violations = int(args.max_violations)


### PR DESCRIPTION
Fixed following two bugs found when loading CCDI Inventory:

1. loading mode set in configuration files are not used (always set to default CLI loading mode "upsert")
2. Relationships will not be created when parent and child nodes use the same ID field names (e.g., both use "id" field as key).