### PR TITLE
Mulit-query index loading

### DIFF
--- a/config.py
+++ b/config.py
@@ -46,7 +46,6 @@ class BentoConfig:
             self.upload_log_dir = None
             self.verbose = None
             self.plugins = []
-            self.page_size = None
         else:
             if os.path.isfile(config_file):
                 with open(config_file) as c_file:
@@ -107,7 +106,6 @@ class BentoConfig:
                     self.split_transactions = config.get('split_transactions')
                     self.upload_log_dir = config.get('upload_log_dir')
                     self.verbose = config.get('verbose')
-                    self.page_size = config.get('page_size')
             else:
                 msg = f'Can NOT open configuration file "{config_file}"!'
                 self.log.error(msg)

--- a/config/es_indices.example.yml
+++ b/config/es_indices.example.yml
@@ -68,31 +68,31 @@ Indices:
               study_subject_source_id: ss.study_subject_source_id,
               taxon: ss.taxon,
               status: ss.status
-          } AS output_data
+          } AS opensearch_data
           SKIP $skip LIMIT $limit
           OPTIONAL MATCH (ss)-->(:study)-->(p:program)
-          WITH ss, apoc.map.merge(output_data, {
+          WITH ss, apoc.map.merge(opensearch_data, {
               program: p.program_acronym,
               program_id: p.program_id
-          }) AS output_data
+          }) AS opensearch_data
           OPTIONAL MATCH (ss)-->(s:study)
-          WITH ss, apoc.map.merge(output_data, {
+          WITH ss, apoc.map.merge(opensearch_data, {
               study_acronym: s.study_acronym,
               study: s.study_name,
               study_description: s.study_short_description
-          }) AS output_data
+          }) AS opensearch_data
           OPTIONAL MATCH (ss)<-[*..2]-()<--(f:file)
-          WITH ss, apoc.map.merge(output_data, {
+          WITH ss, apoc.map.merge(opensearch_data, {
               file_types: COLLECT(DISTINCT f.file_type),
               file_ids: COLLECT(DISTINCT f.file_id)
-          }) AS output_data
+          }) AS opensearch_data
           OPTIONAL MATCH (ss)<--(samp:sample)
-          WITH ss, apoc.map.merge(output_data, {
+          WITH ss, apoc.map.merge(opensearch_data, {
               sample_ids: COLLECT(DISTINCT samp.sample_id),
               tissue_types: COLLECT(DISTINCT samp.tissue_type),
               sample_compositions: COLLECT(DISTINCT samp.composition)
-          }) AS output_data
-          RETURN output_data
+          }) AS opensearch_data
+          RETURN opensearch_data
         # the page size used if this query has pagination variables
         page_size: 10000
   - index_name: about_page

--- a/config/es_indices.example.yml
+++ b/config/es_indices.example.yml
@@ -1,96 +1,154 @@
   # Indices settings
 Indices:
-  # First index
-  # Name of the index to be created, existing index with same name will be deleted
-  - index_name: dashboard
+    # the name of the index to be created, existing indices with same name will be deleted
+  - index_name: cases
+    # index type, this index is initialized with a neo4j cypher query
     type: neo4j
     # type mapping for each property of the index
     mapping:
-      programs:
+      case_id:
         type: keyword
-      studies:
+      disease_type:
         type: keyword
-      subject_id:
+      case_report_form_submitted:
         type: keyword
-      diagnoses:
+      in_analysis:
         type: keyword
-      rc_scores:
+      lost_to_follow_up:
         type: keyword
-      tumor_sizes:
+      consent_type:
         type: keyword
-      chemo_regimen:
+      primary_site:
         type: keyword
-      tumor_grades:
+      consent_withdrawn:
         type: keyword
-      er_status:
+      disease_subtype:
         type: keyword
-      pr_status:
+      study_subject_source_id:
         type: keyword
-      endo_therapies:
+      taxon:
         type: keyword
-      meno_status:
+      status:
         type: keyword
-      tissue_type:
+      program:
         type: keyword
-      composition:
+      program_id:
         type: keyword
-      association:
+      study_acronym:
         type: keyword
-      file_type:
+      study:
         type: keyword
-
-    # Cypher query will be used to retrieve data from Neo4j, and index into Elasticsearch
-    cypher_query: "
-      MATCH (ss)<-[:sf_of_study_subject]-(sf)
-      MATCH (ss)<-[:diagnosis_of_study_subject]-(d)<-[:tp_of_diagnosis]-(tp)
-      MATCH (ss:study_subject)-[:study_subject_of_study]->(s)-[:study_of_program]->(p)
-      MATCH (ss)<-[:demographic_of_study_subject]-(demo)
-      MATCH (ss)<-[:sample_of_study_subject]-(samp)
-      MATCH (ss)<-[*..2]-(parent)<--(f:file)
-      OPTIONAL MATCH (f)-[:file_of_laboratory_procedure]->(lp)
-      OPTIONAL MATCH (ss)-[:study_subject_of_study]->(s)-[:study_of_program]->(p)
-      OPTIONAL MATCH (ss)<-[:sf_of_study_subject]-(sf)
-      OPTIONAL MATCH (ss)<-[:diagnosis_of_study_subject]-(d)
-      OPTIONAL MATCH (d)<-[:tp_of_diagnosis]-(tp)
-      OPTIONAL MATCH (ss)<-[:demographic_of_study_subject]-(demo)
-      RETURN
-      p.program_acronym AS programs,
-      (s.study_acronym + ': ' + s.study_short_description) AS studies,
-      ss.study_subject_id AS subject_id,
-      ss.disease_subtype AS diagnoses,
-      sf.grouped_recurrence_score AS rc_scores,
-      d.tumor_size_group AS tumor_sizes,
-      tp.chemotherapy_regimen AS chemo_regimen,
-      d.tumor_grade AS tumor_grades,
-      d.er_status AS er_status,
-      d.pr_status AS pr_status,
-      tp.endocrine_therapy_type AS endo_therapies,
-      demo.menopause_status AS  meno_status,
-      COLLECT(DISTINCT samp.tissue_type) AS tissue_type,
-      COLLECT(DISTINCT samp.composition) AS composition,
-      COLLECT(DISTINCT head(labels(parent))) AS association,
-      COLLECT(DISTINCT f.file_type) AS file_type
-      "
-  # Second index
-  # Name of the index to be created, existing index with same name will be deleted
-  - index_name: subjects
-    type: neo4j
-      # type mapping for each property of the index
+      study_description:
+        type: keyword
+      file_types:
+        type: keyword
+      file_ids:
+        type: keyword
+      sample_ids:
+        type: keyword
+      tissue_types:
+        type: keyword
+      sample_compositions:
+        type: keyword
+    # a list of the queries that are used to initialize the index
+    cypher_queries:
+        # the cypher query used for initialization
+      - query: |
+          MATCH (ss:study_subject)
+          WITH ss, {
+              case_id: ss.study_subject_id,
+              disease_type: ss.disease_type,
+              case_report_form_submitted: ss.case_report_form_submitted,
+              in_analysis: ss.in_analysis,
+              lost_to_follow_up: ss.lost_to_follow_up,
+              consent_type: ss.consent_type,
+              primary_site: ss.primary_site,
+              consent_withdrawn: ss.consent_withdrawn,
+              disease_subtype: ss.disease_subtype,
+              study_subject_source_id: ss.study_subject_source_id,
+              taxon: ss.taxon,
+              status: ss.status
+          } AS output_data
+          SKIP $skip LIMIT $limit
+          OPTIONAL MATCH (ss)-->(:study)-->(p:program)
+          WITH ss, apoc.map.merge(output_data, {
+              program: p.program_acronym,
+              program_id: p.program_id
+          }) AS output_data
+          OPTIONAL MATCH (ss)-->(s:study)
+          WITH ss, apoc.map.merge(output_data, {
+              study_acronym: s.study_acronym,
+              study: s.study_name,
+              study_description: s.study_short_description
+          }) AS output_data
+          OPTIONAL MATCH (ss)<-[*..2]-()<--(f:file)
+          WITH ss, apoc.map.merge(output_data, {
+              file_types: COLLECT(DISTINCT f.file_type),
+              file_ids: COLLECT(DISTINCT f.file_id)
+          }) AS output_data
+          OPTIONAL MATCH (ss)<--(samp:sample)
+          WITH ss, apoc.map.merge(output_data, {
+              sample_ids: COLLECT(DISTINCT samp.sample_id),
+              tissue_types: COLLECT(DISTINCT samp.tissue_type),
+              sample_compositions: COLLECT(DISTINCT samp.composition)
+          }) AS output_data
+          RETURN output_data
+        # the page size used if this query has pagination variables
+        page_size: 10000
+  - index_name: about_page
+    type: about_file
+    # type mapping for each property of the index
     mapping:
-      subject_id:
+      page:
         type: keyword
-    # Cypher query will be used to retrieve data from Neo4j, and index into Elasticsearch
-    cypher_query: "MATCH (ss:study_subject) return ss.study_subject_id AS subject_id"
-
-    - index_name: about_page
-      type: about_file
-      # type mapping for each property of the index
-      mapping:
-        page:
-          type: search_as_you_type
-        title:
-          type: search_as_you_type
-        primaryContentImage:
-          type: text
-        content:
-          type: text
+      title:
+        type: keyword
+      primaryContentImage:
+        type: text
+      content:
+        type: object
+  - index_name: model_nodes
+    type: model
+    subtype: node
+    # type mapping for each property of the index
+    mapping:
+      node:
+        type: keyword
+      node_kw:
+        type: keyword
+  - index_name: model_properties
+    type: model
+    subtype: property
+    # type mapping for each property of the index
+    mapping:
+      node:
+        type: keyword
+      property:
+        type: keyword
+      property_kw:
+        type: keyword
+      property_description:
+        type: keyword
+      property_required:
+        type: keyword
+      property_type:
+        type: keyword
+  - index_name: model_values
+    type: model
+    subtype: value
+    # type mapping for each property of the index
+    mapping:
+      node:
+        type: keyword
+      property:
+        type: keyword
+      property_description:
+        type: keyword
+      property_required:
+        type: keyword
+      property_type:
+        type: keyword
+      value:
+        type: keyword
+      value_kw:
+        type: keyword

--- a/config/es_loader.example.yml
+++ b/config/es_loader.example.yml
@@ -15,7 +15,3 @@ Config:
     - bento-model/model-desc/bento_tailorx_model_properties.yaml
 
   prop_file: config/props-bento-ext.yml
-
-  # The page size for the Neo4j queries
-  # pagination will be disabled if this value is missing, less than 1, or a non-numeric value
-  page_size: 50000

--- a/config/es_loader.yml.j2
+++ b/config/es_loader.yml.j2
@@ -4,7 +4,6 @@ Config:
   neo4j_password: "{{ neo4j_password }}"
   es_host: {{ es_host }}
   about_file: {{ about_file }}
-  page_size: {{ page_size }}
   model_files:
     - {{ model_file1 }}
     - {{ model_file2 }}

--- a/docs/es-loader.md
+++ b/docs/es-loader.md
@@ -35,13 +35,11 @@ WITH {
 RETURN opensearch_data
 ```
 ## Pagination
-For large amounts of data, sending multiple paginated index queries may be necessary to avoid exceeding Neo4j memory limits and it can improve query performance in some cases. Both of the following conditions are required for implementing pagination:
-1. The **page_size** configuration variable is set to an integer greater than 1
-2. The index queries in the specified indices file contain the pagination variables **$skip** and **$limit**.
+For large amounts of data, sending multiple paginated index queries may be necessary to avoid exceeding Neo4j memory limits. In some cases, pagination might also improve loading performance. For each index loading query in the "cypher_queries" lists, the following conditions must be met for pagination to be enabled:
+1. The **page_size** property in the "cypher_queries" entry must be present and set to an integer greater than 1
+2. The **query** property in the "cypher_queries" entry must be a cypher query that includes the pagination variables **$skip** and **$limit**.
 
-If either of these conditions are not met, the OpenSearch loader will still run but pagination will be disabled.
-
-**NOTE**: The OpenSearch loader cannot detect if the pagination variables are present in each index loading query. If the **page_size** variable is set to a valid value but the index queries do not contain pagination variables, then the logs will say that pagination is enabled even though the queries are not paginated.
+If either of these conditions are not met, the OpenSearch loader will still run the loading query but pagination will be disabled.
 
 ### Adding Pagination to Index Queries
 Pagination can be added to a query by inserting the following line after a line starting with the **WITH** keyword:


### PR DESCRIPTION
- Allow multiple queries to be used for loading an OpenSearch index
- Allow for specifying a page size for each individual query
- Removed page size variable from the configuration
- Added a summary section to the end of the OpenSearch loading
- Compatible with previous index mapping file format but pagination will be disabled