### PR TITLE
Update the memgraph backup function

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -14,7 +14,7 @@ import datetime
 #import dateutil
 from timeit import default_timer as timer
 from bento.common.utils import get_host, DATETIME_FORMAT, reformat_date, get_time_stamp
-from memgraph_backup_restore import backup_memgraph
+from memgraph_backup_restore import backup_memgraph_mgconsole
 from create_index import create_index
 
 from neo4j import Driver
@@ -256,7 +256,7 @@ class DataLoader:
             return True
 
     def load(self, file_list, cheat_mode, dry_run, loading_mode, wipe_db, max_violations, temp_folder, verbose,
-             split=False, no_backup=True, backup_folder="/", neo4j_uri=None):
+             split=False, no_backup=True, neo4j_uri=None, backup_folder="/", username=None, password=None):
         if self.database_type not in self.allowed_database_type:
             self.log.error('database_type is neither neo4j nor memgraph, abort loading')
             sys.exit(1)
@@ -277,7 +277,7 @@ class DataLoader:
                     self.log.error('Backup Neo4j failed, abort loading!')
                     sys.exit(1)
             elif self.database_type == "memgraph":
-                backup_name = backup_memgraph(backup_folder, self.memgraph_snapshot_dir, self.log)
+                backup_name = backup_memgraph_mgconsole(backup_folder, self.memgraph_snapshot_dir, username, password, self.log)
                 print(backup_name)
                 if not backup_name:
                     self.log.error('Backup Memgraph failed, abort loading!')

--- a/loader.py
+++ b/loader.py
@@ -259,7 +259,7 @@ def main(args):
 
             load_result = loader.load(file_list, config.cheat_mode, config.dry_run, config.loading_mode, config.wipe_db,
                         config.max_violations, config.temp_folder, config.verbose, split=config.split_transactions,
-                        no_backup=config.no_backup, neo4j_uri=config.neo4j_uri, backup_folder=config.backup_folder)
+                        no_backup=config.no_backup, neo4j_uri=config.neo4j_uri, backup_folder=config.backup_folder, username=config.neo4j_user, password=config.neo4j_password)
             
             if load_result == False:
                 if loader.validation_result_file_key != "":

--- a/memgraph_backup_restore.py
+++ b/memgraph_backup_restore.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import subprocess
+import sys
+from bento.common.utils import get_time_stamp
 
 def get_latest_file(src_folder):
     files = [os.path.join(src_folder, f) for f in os.listdir(src_folder) if os.path.isfile(os.path.join(src_folder, f))]
@@ -8,6 +10,25 @@ def get_latest_file(src_folder):
         return None
     latest_file = max(files, key=os.path.getmtime)
     return latest_file
+
+def backup_memgraph_mgconsole(memgraph_backup_dir, memgraph_dump_dir, memgraph_username, memgraph_password, log):
+    try:
+        timestamp = get_time_stamp()
+        memgraph_dump_file_name = "memgraph_dump" + "_" + timestamp + ".cypherl"
+        memgraph_dump_file_key = os.path.join("/"+os.path.basename(memgraph_dump_dir), memgraph_dump_file_name )
+        backup_command = f'''docker exec -it memgraph_docker-memgraph-1 bash -c \
+        'echo "DUMP DATABASE;" | mgconsole \
+        --username {memgraph_username} --password {memgraph_password} --output-format=cypherl > {memgraph_dump_file_key}' \
+        '''
+        subprocess.run(backup_command, shell=True)
+        dump_file_key = os.path.join(memgraph_dump_dir, memgraph_dump_file_name)
+        dest_file_path = os.path.join(memgraph_backup_dir, memgraph_dump_file_name)
+        shutil.copy2(dump_file_key, dest_file_path)
+        log.info(f"Successfully copied the backup snapshot file {dump_file_key} to {dest_file_path}")
+        return dest_file_path
+    except Exception as e:
+        log.error(e)
+        return "Backup Memgraph failed"
 
 def backup_memgraph(memgraph_backup_dir, memgraph_snapshot_dir, log):
     try:


### PR DESCRIPTION
Update the memgraph backup function to use mgconsole command "DUMP DATABASE" to generate the dump file for the memgraph database
The memgraph database needs to mount it's backup folder(for example, "/tmp") to a place where we can easily get access to the filesystem 