### PR TITLE
parameterize max_violations

### DIFF
--- a/config/config.yml.j2
+++ b/config/config.yml.j2
@@ -35,7 +35,7 @@ Config:
   # Automatically confirm deletion and database wiping (without asking user to confirm)
   no_confirmation: true
   # Max violations to display, default is 10
-  max_violations: {{max_violations}}
+  max_violations: 10
   split_transactions: {{split_transactions}}
 
   # S3 bucket name, if you are loading from an S3 bucket

--- a/config/config.yml.j2
+++ b/config/config.yml.j2
@@ -35,7 +35,7 @@ Config:
   # Automatically confirm deletion and database wiping (without asking user to confirm)
   no_confirmation: true
   # Max violations to display, default is 10
-  max_violations: 10
+  max_violations: {{max_violations}}
   split_transactions: {{split_transactions}}
 
   # S3 bucket name, if you are loading from an S3 bucket

--- a/config/icdc_config.yml.j2
+++ b/config/icdc_config.yml.j2
@@ -1,0 +1,48 @@
+Config:
+  temp_folder: tmp
+  backup_folder: /tmp/data-loader-backups
+
+  neo4j:
+    # Location of Neo4j server, e.g., bolt://127.0.0.1:7687
+    uri: bolt://{{neo4j_ip}}:7687
+    # Neo4j username
+    user: neo4j
+    # Neo4j password
+    password: "{{neo4j_password}}"
+
+  # Schema files' locations
+  schema:
+    - {{model_file1}}
+    - {{model_file2}}
+
+  plugins:
+    - module: loader_plugins.visit_creator
+      class: VisitCreator
+    - module: loader_plugins.individual_creator
+      class: IndividualCreator
+
+  #Property file location
+  prop_file: {{property_file}}
+
+  # Skip validations, aka. Cheat Mode
+  cheat_mode: {{cheat_mode}}
+  # Validations only, skip loading
+  dry_run: false
+  # Wipe out database before loading, you'll lose all data!
+  wipe_db: {{wipe_db}}
+  # Skip backup step
+  no_backup: false
+  # Automatically confirm deletion and database wiping (without asking user to confirm)
+  no_confirmation: true
+  # Max violations to display, default is 10
+  max_violations: {{max_violations}}
+  split_transactions: {{split_transactions}}
+
+  # S3 bucket name, if you are loading from an S3 bucket
+  s3_bucket: {{data_bucket}}
+  # S3 folder for dataset
+  s3_folder: {{s3_folder}}
+  # Loading mode, can be "upsert", "new" or "delete", default is "upsert"
+  loading_mode: {{loading_mode}}
+  # Location of dataset
+  dataset: "{{s3_folder}}"


### PR DESCRIPTION
Is it possible to parameterize `max_violations` without disrupting other (i.e. non-ICDC) data loading pipelines?

[ICDC-3852](https://tracker.nci.nih.gov/browse/ICDC-3852): Increase max error reporting parameter for the Data Loader in Jenkins