### PR TITLE
3.2.0 permissive value validation flag update

### DIFF
--- a/config.py
+++ b/config.py
@@ -112,6 +112,7 @@ class BentoConfig:
                     self.database_type = config.get("database_type")
                     self.memgraph_snapshot_dir = config.get("memgraph_snapshot_dir")
                     self.empty_cell_null = config.get("empty_cell_null")
+                    self.skip_permissive_values_validation = config.get("skip_permissive_values_validation")
             else:
                 msg = f'Can NOT open configuration file "{config_file}"!'
                 self.log.error(msg)

--- a/config.py
+++ b/config.py
@@ -49,6 +49,7 @@ class BentoConfig:
             self.plugins = []
             self.memgraph_snapshot_dir = None
             self.empty_cell_null = False
+            self.skip_permissive_values_validation = False
         else:
             if os.path.isfile(config_file):
                 with open(config_file) as c_file:

--- a/config/prefect-data-hub.yaml
+++ b/config/prefect-data-hub.yaml
@@ -17,7 +17,7 @@ pull:
   - prefect.deployments.steps.git_clone:
       #id: clone-step
       repository: https://github.com/CBIIT/icdc-dataloader.git
-      branch: 3.2.0
+      branch: 3.2.0_multi_batch
       include_submodules: True
   - prefect.deployments.steps.git_clone:
       repository: https://github.com/CBIIT/icdc-model-tool.git

--- a/config/prefect-data-hub.yaml
+++ b/config/prefect-data-hub.yaml
@@ -23,7 +23,7 @@ pull:
       repository: https://github.com/CBIIT/icdc-model-tool.git
       branch: master
   - prefect.deployments.steps.set_working_directory:
-      directory: "/opt/prefect/icdc-dataloader-3.2.0"
+      directory: "/opt/prefect/icdc-dataloader-3.2.0_multi_batch"
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/config/prefect-data-hub.yaml
+++ b/config/prefect-data-hub.yaml
@@ -61,6 +61,7 @@ deployments:
       s3_folder: []
       s3_bucket: "{{ prefect.variables.gc_metadata_lowertier_bucket }}"
       cheat_mode: True
+      skip_permissive_values_validation: False
       dry_run: False
       wipe_db: False
       mode: "upsert"

--- a/config/prefect-data-hub.yaml
+++ b/config/prefect-data-hub.yaml
@@ -17,13 +17,13 @@ pull:
   - prefect.deployments.steps.git_clone:
       #id: clone-step
       repository: https://github.com/CBIIT/icdc-dataloader.git
-      branch: 3.2.0_multi_batch
+      branch: 3.2.0
       include_submodules: True
   - prefect.deployments.steps.git_clone:
       repository: https://github.com/CBIIT/icdc-model-tool.git
       branch: master
   - prefect.deployments.steps.set_working_directory:
-      directory: "/opt/prefect/icdc-dataloader-3.2.0_multi_batch"
+      directory: "/opt/prefect/icdc-dataloader-3.2.0"
   - prefect.deployments.steps.pip_install_requirements:
       requirements_file: requirements.txt
       directory: "{{ clone-step.directory }}"

--- a/data_loader.py
+++ b/data_loader.py
@@ -229,14 +229,14 @@ class DataLoader:
         return validation_result
 
 
-    def validate_files(self, cheat_mode, loading_mode, file_list, max_violations, temp_folder, verbose):
+    def validate_files(self, cheat_mode, loading_mode, file_list, max_violations, temp_folder, verbose, skip_permissive_values_validation=False):
         if not cheat_mode:
             if loading_mode != DELETE_MODE:
                 self.cheat_mode = False
                 validation_failed = False
                 output_key_invalid = ""
                 for txt in file_list:
-                    validate_result = self.validate_file(txt, max_violations, verbose)
+                    validate_result = self.validate_file(txt, max_violations, verbose, skip_permissive_values_validation)
                     if not validate_result:
                         self.log.error('Validating file "{}" failed!'.format(txt))
                         validation_failed = True
@@ -266,11 +266,11 @@ class DataLoader:
             return True
 
     def load(self, file_list, cheat_mode, dry_run, loading_mode, wipe_db, max_violations, temp_folder, verbose,
-             split=False, no_backup=True, neo4j_uri=None, backup_folder="/", username=None, password=None, empty_cell_null=False):
+             split=False, no_backup=True, neo4j_uri=None, backup_folder="/", username=None, password=None, empty_cell_null=False, skip_permissive_values_validation=False):
         if not self.check_files(file_list):
             return False
         start = timer()
-        if not self.validate_files(cheat_mode, loading_mode, file_list, max_violations, temp_folder, verbose):
+        if not self.validate_files(cheat_mode, loading_mode, file_list, max_violations, temp_folder, verbose, skip_permissive_values_validation):
             return False
         if not no_backup and not dry_run:
             if not neo4j_uri:
@@ -638,7 +638,7 @@ class DataLoader:
         df_validation_result = pd.concat([df_validation_result, tmp_df_validation_result_field])
         return df_validation_result
     # Validate file
-    def validate_file(self, file_name, max_violations, verbose):
+    def validate_file(self, file_name, max_violations, verbose, skip_permissive_values_validation=False):
         self.skip_validation_flag = False
         file_encoding = check_encoding(file_name)
         with open(file_name, encoding=file_encoding) as in_file:
@@ -694,7 +694,7 @@ class DataLoader:
                     else:
                         ids[node_id] = {'props': get_props_signature(props), 'lines': [str(line_num)]}
 
-                validate_result = self.schema.validate_node(obj[NODE_TYPE], obj, verbose)
+                validate_result = self.schema.validate_node(obj[NODE_TYPE], obj, verbose, skip_permissive_values_validation)
                 try:
                     if len(validate_result['invalid_properties']) > 0:
                         tmp_df_invalid = pd.DataFrame()

--- a/icdc_schema.py
+++ b/icdc_schema.py
@@ -401,7 +401,7 @@ class ICDC_Schema:
     def get_original_value_property_name(name):
         return name + '_original'
 
-    def validate_node(self, model_type, obj, verbose):
+    def validate_node(self, model_type, obj, verbose, skip_permissive_values_validation=False):
         result = {'result': True, 'messages': [], 'warning': False, 'invalid_values': [], 'invalid_properties': [], 'invalid_reason': [], 'missing_properties': [], 'missing_reason': []}
         if not model_type or model_type not in self.nodes:
             return {'result': False, 'messages': ['Node type: "{}" not found in data model'.format(model_type)], 'warning': False}
@@ -444,7 +444,7 @@ class ICDC_Schema:
                     continue
 
                 prop_type = self.relationship_props[rel_type][PROPERTIES][rel_prop]
-                type_validation_result, error_type = self._validate_type(prop_type, value)
+                type_validation_result, error_type = self._validate_type(prop_type, value, skip_permissive_values_validation)
                 if not type_validation_result:
                     result['result'] = False
                     result['invalid_values'].append(value)
@@ -465,7 +465,7 @@ class ICDC_Schema:
                 self.log.debug('Property "{}" is not in data model!'.format(key))
             else:
                 prop_type = properties[key]
-                type_validation_result, error_type = self._validate_type(prop_type, value)
+                type_validation_result, error_type = self._validate_type(prop_type, value, skip_permissive_values_validation)
                 if not type_validation_result:
                     if type(error_type) is tuple:
                         result['result'] = False
@@ -525,7 +525,7 @@ class ICDC_Schema:
                 return False
         return True
 
-    def _validate_type(self, model_type, str_value):
+    def _validate_type(self, model_type, str_value, skip_permissive_values_validation=False):
         wrong_type = "wrong_type"
         out_of_range = "out_of_range"
         non_permissive_value = "non_permissive_value"
@@ -553,7 +553,7 @@ class ICDC_Schema:
                 return False, wrong_type
         elif model_type[PROP_TYPE] == 'Array':
             for item in self.get_list_values(str_value):
-                if ENUM in model_type[ITEM_TYPE]:
+                if ENUM in model_type[ITEM_TYPE] and not skip_permissive_values_validation:
                     validation_result, error_type = self._validate_type(model_type[ITEM_TYPE], item)
                     if not validation_result:
                         return False, (item, error_type)
@@ -565,7 +565,7 @@ class ICDC_Schema:
             if not isinstance(str_value, dict):
                 return False, wrong_type
         elif model_type[PROP_TYPE] == 'String':
-            if ENUM in model_type:
+            if ENUM in model_type and not skip_permissive_values_validation:
                 if not isinstance(str_value, str):
                     return False, wrong_type
                 if str_value != '' and str_value not in model_type[ENUM]:

--- a/loader.py
+++ b/loader.py
@@ -55,6 +55,7 @@ def parse_arguments(args = None):
     parser.add_argument('--upload-log-dir', help='Upload destination dir for log file,  if dir in s3, use the format, s3://[bucket]/[prefix]')
     parser.add_argument('--database-type', help='The database type, can be either neo4j or memgraph', choices=[NEO4J, MEMGRAPH])
     parser.add_argument('--empty-cell-null', help='Whether to treat empty cell as null value instead of empty string, default is false', action='store_true')
+    parser.add_argument('--skip-permissive-values-validation', help='Whether to skip empty cells instead of treating them as null values, default is false', action='store_true')
     return parser.parse_args(args)
 
 
@@ -209,12 +210,15 @@ def process_arguments(args, log):
             log.error('database_type is neither neo4j nor memgraph, abort loading')
             sys.exit(1)
 
+    if args.empty_cell_null:
+        config.empty_cell_null = args.empty_cell_null
     if not config.empty_cell_null:
         config.empty_cell_null = False
     if config.empty_cell_null not in [True, False]:
         log.error('empty_cell_null should be a boolean value, abort loading')
         sys.exit(1)
-    
+    if args.skip_permissive_values_validation:
+        config.skip_permissive_values_validation = args.skip_permissive_values_validation
     if not config.skip_permissive_values_validation:
         config.skip_permissive_values_validation = False
     if config.skip_permissive_values_validation not in [True, False]:

--- a/loader.py
+++ b/loader.py
@@ -214,6 +214,12 @@ def process_arguments(args, log):
     if config.empty_cell_null not in [True, False]:
         log.error('empty_cell_null should be a boolean value, abort loading')
         sys.exit(1)
+    
+    if not config.skip_permissive_values_validation:
+        config.skip_permissive_values_validation = False
+    if config.skip_permissive_values_validation not in [True, False]:
+        log.error('skip_permissive_values_validation should be a boolean value, abort loading')
+        sys.exit(1)
 
     if args.database_type:
         config.database_type = args.database_type
@@ -292,7 +298,7 @@ def main(args):
 
                 load_result = loader.load(file_list, config.cheat_mode, config.dry_run, config.loading_mode, config.wipe_db,
                             config.max_violations, config.temp_folder, config.verbose, split=config.split_transactions,
-                            no_backup=config.no_backup, neo4j_uri=config.neo4j_uri, backup_folder=config.backup_folder, username=config.neo4j_user, password=config.neo4j_password, empty_cell_null=config.empty_cell_null)
+                            no_backup=config.no_backup, neo4j_uri=config.neo4j_uri, backup_folder=config.backup_folder, username=config.neo4j_user, password=config.neo4j_password, empty_cell_null=config.empty_cell_null, skip_permissive_values_validation=config.skip_permissive_values_validation)
                 
                 if load_result == False:
                     if loader.validation_result_file_key != "":

--- a/loader_prefect.py
+++ b/loader_prefect.py
@@ -97,7 +97,8 @@ def load_data(
         mode = "upsert",
         split_transaction = False,
         plugins = [],
-        empty_cell_null = True
+        empty_cell_null = True,
+        skip_permissive_values_validation = False
     ):
 
     params = Config(
@@ -124,7 +125,8 @@ def load_data(
         upload_log_dir,
         plugins,
         temp_folder,
-        empty_cell_null
+        empty_cell_null,
+        skip_permissive_values_validation
     )
     main(params)
 
@@ -202,7 +204,8 @@ def data_hub_loader(
         no_parents=True,
         plugins=[],
         split_transaction=True,
-        empty_cell_null=True
+        empty_cell_null=True,
+        skip_permissive_values_validation=False
     ):
     secret_name = Variable.get(config_drop_list[ENVIRONMENTS][environment])
     secret = get_secret(secret_name)
@@ -240,7 +243,8 @@ def data_hub_loader(
         mode = mode,
         plugins = plugins,
         split_transaction = split_transaction,
-        empty_cell_null = empty_cell_null
+        empty_cell_null = empty_cell_null,
+        skip_permissive_values_validation = skip_permissive_values_validation
     )
 
 if __name__ == "__main__":

--- a/loader_prefect.py
+++ b/loader_prefect.py
@@ -156,7 +156,8 @@ class Config:
             upload_log_dir,
             plugins,
             temp_folder,
-            empty_cell_null
+            empty_cell_null,
+            skip_permissive_values_validation
 
     ):
         self.dataset = dataset
@@ -183,6 +184,7 @@ class Config:
         self.temp_folder = temp_folder
         self.database_type = database_type
         self.empty_cell_null = empty_cell_null
+        self.skip_permissive_values_validation = skip_permissive_values_validation
         for plugin in plugins:
             self.plugins.append(PluginConfig(plugin))
 


### PR DESCRIPTION
add flag to disable permissive values validation and keep other validations because current permissive value validation only validation againist model ENUM values. The default permissive value validation flag is set as ture, when user set this flag to false, the data loader will skip the permissive value validation but still keep other validations.